### PR TITLE
Support unencrypted saves

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,15 +16,15 @@ const button = document.querySelector('#button');
 input.addEventListener('change', submitform);
 
 function submitform() {
-    var file = document.getElementById("myFile").files[0];
+	var file = document.getElementById("myFile").files[0];
 
-    var reader = new FileReader();
-    reader.onload = function({target}) {
-        const jsonF = JSON.parse(target.result);
+	var reader = new FileReader();
+	reader.onload = function({target}) {
+		const jsonF = JSON.parse(target.result);
 		loadSaveFile(jsonF);
-    };
-    reader.readAsText(file);
-    loadedSave = true;
+	};
+	reader.readAsText(file);
+	loadedSave = true;
 }
 
 const slotTemplate = document.querySelector("#slot");
@@ -40,7 +40,7 @@ function loadSaveFile(json) {
 
 	if (json.autoSlot) {
 		nodes.push(createSlotElement(-1));
-	} 
+	}
 
 	const slots = json.slots;
 	for (let i = 0; i < slots.length; i++) {
@@ -72,7 +72,7 @@ function createSlotElement(slotIndex) {
 
 function loadSlot(slot){
 	activeSlot = slot;
-	
+
 	let component = null;
 	if (isFinite(slot)) {
 		if (slot === "-1") {
@@ -91,11 +91,11 @@ function loadSlot(slot){
 }
 
 function encode(s) {
-    var out = [];
-    for (var i = 0; i < s.length; i++) {
-        out[i] = s.charCodeAt(i);
-    }
-    return new Uint8Array(out);
+	var out = [];
+	for (var i = 0; i < s.length; i++) {
+		out[i] = s.charCodeAt(i);
+	}
+	return new Uint8Array(out);
 }
 
 function loadSaveComponent(slot, data) {
@@ -129,34 +129,34 @@ function compileChanges() {
 }
 
 function exportSave() {
-    if (jsonFile) {
-        var data = encode(JSON.stringify(compileChanges(), null, 4));
-        var blob = new Blob([data], {
-            type: 'application/octet-stream'
-        });
+	if (jsonFile) {
+		var data = encode(JSON.stringify(compileChanges(), null, 4));
+		var blob = new Blob([data], {
+			type: 'application/octet-stream'
+		});
 
-        url = URL.createObjectURL(blob);
-        var link = document.createElement('a');
-        link.setAttribute('href', url);
-        link.setAttribute('download', 'cc.save');
+		url = URL.createObjectURL(blob);
+		var link = document.createElement('a');
+		link.setAttribute('href', url);
+		link.setAttribute('download', 'cc.save');
 
-        var event = document.createEvent('MouseEvents');
-        event.initMouseEvent('click', true, true, window, 1, 0, 0, 0, 0, false, false, false, false, 0, null);
-        link.dispatchEvent(event);
-    }
+		var event = document.createEvent('MouseEvents');
+		event.initMouseEvent('click', true, true, window, 1, 0, 0, 0, 0, false, false, false, false, 0, null);
+		link.dispatchEvent(event);
+	}
 }
 
 function decrypt(data, key) {
-    if (key = 75 * key + "0") key = ":_." + key;
-    var c = window.CryptoJS,
+	if (key = 75 * key + "0") key = ":_." + key;
+	var c = window.CryptoJS,
 	data = data.substr(9, data.length);
-    return c.AES.decrypt(data, key).toString(c.enc.Utf8);
+	return c.AES.decrypt(data, key).toString(c.enc.Utf8);
 }
 
 
 function encrypt(data, key) {
-    var c;
-    if (key = 75 * key + "0") key = ":_." + key;
-    c = window.CryptoJS.AES.encrypt(data, key).toString();
-    return "[-!_0_!-]" + c;
+	var c;
+	if (key = 75 * key + "0") key = ":_." + key;
+	c = window.CryptoJS.AES.encrypt(data, key).toString();
+	return "[-!_0_!-]" + c;
 }


### PR DESCRIPTION
The game actually supports them by default because of checks like:

```js
if (ig.StorageTools.isEncrypted(a)) {
  a = ig.StorageTools.decrypt(a);
  a = JSON.parse(a);
}
```

I utilize that behavior in [crosscode-readable-saves](https://github.com/dmitmel/crosscode-readable-saves) (see my rant in the README), so I decided that it would be nice if the most commonly used save editor supported them as well.